### PR TITLE
streamlined installation process. automated timeseries yaml creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - old formatting for instrument names, channel numbers, assimilation status, subplot titles, and legends
 - Fix LaTeX subscript issue in instrument names by escaping underscores (e.g., ATMS_NPP)
 - Adjust title spacing and assimilation status text positioning for improved layout
+- Automted installation process and creation of timeseries yamls. Updated README instructions.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,107 +1,188 @@
 ========
-# pyradmon
 
-</div>
+pyradmon
 
 Python Radiance Monitoring Tool. Contains both spatial and timeseries pyradmon.
 
+## TL;DR - Quick Start
 
-The Radiance monitoring tool, `pyradmon`, has been overhauled after compatibility issues caused by the transition from SLES12 to SLES15. Most of the changes were the addition of python scripts for the front end and edits to make backend shell scripts work with the new python scripts. The edits on the backend were to only a few, albeit important, scripts. Backend python scripts were also edited slightly to account for changes to the directory structure within the repository and to account for updates to packages like matplotlib which were part of the issues during the OS transition. 
+**First time setup:**
+```sh
+cd $NOBACKUP
+mkdir -p $NOBACKUP/pyradmon-project
+cd pyradmon-project
+git clone https://github.com/GEOS-ESM/pyradmon.git
+cd pyradmon
+```
+
+**Every session - Load environment (must be in repo root):**
+```csh
+source load_radmon_config.csh  # or load_radmon_config.sh for bash/zsh
+```
+
+
+**Add mod_pyradmon alias:** Add `mod_pyradmon` alias to your shell rc file to load (see [Environment Setup](#load-pyradmon-environment-setup--environment-variables)).
+```csh
+alias mod_pyradmon ' setenv PYRADMON $NOBACKUP/pyradmon-project/pyradmon ; \
+                     cd $PYRADMON ; \
+                     module load miniforge ; \
+                     source $PYRADMON/load_radmon_config.csh'  # or load_radmon_config.sh for bash/zsh
+```
+
+Resuming work from a previous - use the `mod_pyradmon` alias to load pyradmon 
+
+
+
+**Run spatial:**
+```sh
+cd $PYRADMON_SPATIAL
+cp test_config.geosfp.yaml user_geosfp_spatial_input.yaml
+# Edit my_config.yaml: set dates, expver, turn obs switches on/off
+python3 pyradmon_driver_spatial.py user_geosfp_spatial_input.yaml
+```
+
+**Run timeseries:**
+```sh
+cd $PYRADMON_TIMESERIES
+# Auto-generated yamls ready to use: user_geosit_timeseries_input.yaml or user_m21c_timeseries_input.yaml
+# Edit if needed: dates, expid, data paths, instruments
+python3 pyradmon_driver_timeseries.py user_m21c_timeseries_input.yaml
+```
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Installation and Environment Setup](#installation-and-environment-setup)
+   - [First Time Installation](#first-time-installing-pyradmon)
+   - [Load Environment](#load-pyradmon-environment-setup--environment-variables)
+3. [How to Run](#how-to-run)
+   - [Spatial](#spatial)
+   - [Timeseries](#timeseries)
+4. [License](#license)
+
+---
+
+## Overview
+
+The Radiance monitoring tool, pyradmon, has been overhauled after compatibility issues caused by the transition from SLES12 to SLES15. Most of the changes were the addition of python scripts for the front end and edits to make backend shell scripts work with the new python scripts. The edits on the backend were to only a few, albeit important, scripts. Backend python scripts were also edited slightly to account for changes to the directory structure within the repository and to account for updates to packages like matplotlib which were part of the issues during the OS transition.
 
 Returning users can expect the final outputs (plots) pyradmon produces to be the same as it did previously – plots should be formatted in the same style, etc. While pyradmon is running, users should expect to see similar – but different - output in the terminal. The location of the output images and .tar file will be in a different location – the .tar file will have the same structure as it did previously.
 
-The current version of pyradmon: 
+<!-- The current version of pyradmon:
 - is working for both timeseries and spatial plotting.
-- is a 'pointer' - the python wrappers _point_ to the backend scripts that are in `/home/dao_ops/pyradmon/` NOT the ones that are in the source directories in this repository. 
+- is a 'pointer' - the python wrappers point to the backend scripts that are in /home/dao_ops/pyradmon/ NOT the ones that are in the source directories in this repository. -->
 
-<!-- ~~Further explanation of the _'pointer'_ version and why it was made this way:~~ -->
+<!-- More changes are being made to make it more flexible and user friendly. -->
+Users should be careful not overwrite their initial source code of this repo when there is an update.
 
-More changes are being made to make it more flexible and user friendly. 
+---
 
-**Users should be careful not overwrite their initial source code of this repo when there is an update.**
+## Installation and Environment Setup
 
-</div>
-
-# Installation and Environment Setup
-
-
-Pyradmon is a package consisting of Python wrappers (drivers) that take user created yamls as input on the front end and a combination of python, shell, and perl scripts on the backend. 
-
-Once setup is complete users will use, or interact with, **5 files** when running `pyradmon`: **3 scripts and 2 yamls.**
--	One .sh script for loading pyradmon
--	Two python scripts ~ one for running pyradmon timeseries & one for running pyradmon spatial
--	Two yaml files ~ one for running pyradmon timeseries & one for running pyradmon spatial
+Pyradmon is a package consisting of Python wrappers (drivers) that take user created yamls as input on the front end and a combination of python, shell, and perl scripts on the backend.
+<!-- 
+Once setup is complete users will use, or interact with, 5 files when running pyradmon: 3 scripts and 2 yamls.
+- One .csh or .sh script for loading pyradmon
+- Two python scripts ~ one for running pyradmon timeseries & one for running pyradmon spatial
+- Two yaml files ~ one for running pyradmon timeseries & one for running pyradmon spatial -->
 
 ### First time installing pyradmon:
+
 Clone pyradmon to wherever you want to live, for example:
 
 ```sh
 cd $NOBACKUP
-mkdir -p radmon && cd radmon
+mkdir -p pyradmon-project && cd pyradmon-project
 git clone https://github.com/GEOS-ESM/pyradmon.git
-cd $NOBACKUP/radmon/pyradmon
+cd $NOBACKUP/pyradmon-project/pyradmon
 ```
-<!-- 
-This will be for after the feature/dao-ops-pointer branch has been merged to the main branch
 
+### Load pyradmon (environment setup & environment variables)
 
-~~mkdir -p radmon && cd radmon~~
-~~git clone https://github.com/GEOS-ESM/pyradmon.git pyradmon~~
-~~cd pyradmon~~ -->
-<!-- 
-After running the venv steps above, from now on use `load_radmon_config.sh` to load and activate the pyradmon virtual environment. It contains the line `source .venv/radmon_sles15_venv/bin/activate.csh` and defines other environment variables that will be used by the pyradmon scripts. There should be no need to edit `load_radmon_config.sh` unless you need to change which `activate` line for your shell.
- -->
+**IMPORTANT:** The load script must be run from the repository root directory (where `load_radmon_config.csh` and the `offline/` directory are located).
 
-<!-- 
-#### Part 1: virtual environment
+<!-- You will no longer need to create or activate your virtual environment directly.  -->
+The load script handles environment setup automatically.
 
-1) Switch to your folder where pyradmon is cloned: `cd $NOBACKUP/radmon/pyradmon`.
-2) Create a Python virtual environment: `python3 -m venv .venv`
-3) Activate the virtual environment - this step will vary depending on the shell you're using. 
-  - `source .venv/bin/activate`
-  - `source .venv/bin/activate.csh` for csh users 
-4) Install pyradmon dependencies `pip install -r requirements.txt`
-5) (_Optional_) Deactivate the virtual environment: `deactivate`
+From now on, in order to load pyradmon you must use the appropriate `load_radmon_config.*` script. These scripts:
+- Verify you are in the repository root directory
+- Load the g5_modules
+- Set environment variables that the pyradmon scripts will use ($PYRADMON, $PYRADMON_SPATIAL, $PYRADMON_TIMESERIES, $PYRADMON_RUN)
+- Auto-generate personalized timeseries input yaml files
 
-#### Part 2: Load pyradmon (virtual environment & environment variables)
+**For csh/tcsh users:**
+```csh
+source load_radmon_config.csh
+```
 
- You will no longer need to activate your virtual environment directly. 
- 
- From now on, in order to load `pyradmon` you must use the appropriate `load_radmon_config.*sh` script. These scripts runs the `source .venv/bin/activate` command for activating your virtual environment and sets environment variables that the `pyradmon` scripts will use.
+**For bash/zsh users:**
+```sh
+source load_radmon_config.sh
+```
 
-6) Load with the appropriate `load_radmon_config` script: `source load_radmon_config.csh` -->
+**Optional - Add a convenience alias to your shell rc file:**
 
-<!-- 2) Load all the modules that pyradmon needs: `mod_load_pyradmon` (this is the `bash` function created in the preliminary steps) -->
+For csh/tcsh (.cshrc):
+```csh
+alias mod_pyradmon 'setenv PYRADMON $NOBACKUP/pyradmon-project/pyradmon ; \
+                    cd $PYRADMON ; \
+                    module load miniforge ; \
+                    source $PYRADMON/load_radmon_config.csh'
+```
 
-#### Load pyradmon (virtual environment & environment variables)
+For bash/zsh (.bashrc/.zshrc):
+```sh
+alias mod_pyradmon='export PYRADMON=$NOBACKUP/pyradmon-project/pyradmon ; \
+                    cd $PYRADMON ; \
+                    module load miniforge ; \
+                    source $PYRADMON/load_radmon_config.sh'
+```
 
- You will no longer need to create or activate your virtual environment directly. 
- 
- From now on, in order to load `pyradmon` you must use the appropriate `load_radmon_config.*sh` script. These scripts runs the command for activating loading the `g5_modules` and sets environment variables that the `pyradmon` scripts will use.
+Then you can simply run `mod_pyradmon` from anywhere to load the environment.
 
-0) Load with the appropriate `load_radmon_config` script: `source load_radmon_config.csh`
+---
 
-# How to run
+## How to run
 
-## Spatial: 
+### Spatial:
 
 ```sh
 python3 pyradmon_driver_spatial.py [user_input_yaml]
 ```
 
-1) Load with the appropriate `load_radmon_config` `source load_radmon_config.csh` this well set $pyradmon 
-2) Change directory: `cd $pyradmon/offline/spatial/src`
-3) Create the `user_input_yaml` by copying the existing example yaml. You may name the yaml file whatever you like: `cp test_config.geosfp.yaml user_input_yaml.yaml`
-4) Open and edit yaml to the experiment and dates you wish to run pyradmon for. Set the Obs Types switches to `1 for ON` and `0 for OFF`
-5) Run pyradmon spatial: `python3 pyradmon_driver_spatial.py user_input_yaml.yaml`
+1) Navigate to the repository root and load pyradmon:
+   ```csh
+   cd $NOBACKUP/pyradmon-project/pyradmon
+   source load_radmon_config.csh
+   ```
 
-#### Example user_input_yaml: `test_config.geosfp.yaml`:
+2) Change to the spatial source directory:
+   ```sh
+   cd $PYRADMON_SPATIAL
+   ```
+
+3) Create your user input yaml by copying an existing example yaml. You may name the yaml file whatever you like:
+   ```sh
+   cp test_config.geosfp.yaml user_input_yaml.yaml
+   ```
+
+4) Open and edit the yaml to the experiment and dates you wish to run pyradmon for. Set the Obs Types switches to 1 for ON and 0 for OFF
+
+5) Run pyradmon spatial:
+   ```sh
+   python3 pyradmon_driver_spatial.py user_input_yaml.yaml
+   ```
+
+**Example user_input_yaml: test_config.geosfp.yaml:**
 
 The example will only run pyradmon spatial for gmi.
 
-```
-# config for pyradmon_driver_spatial.py 
+```yaml
+# config for pyradmon_driver_spatial.py
 # -------------------------------------
+
 expver: f5295_fp
 yyyymmdd: '20250301'
 hh: '18'
@@ -123,178 +204,105 @@ airs: 0
 iasi: 0
 ```
 
-pyradmon should be the full path to the users local clone of pyradmon: {userid}/.../pyradmon
-
-
-## Timeseries: 
+### Timeseries:
 
 ```sh
 python3 pyradmon_driver_timeseries.py [user_input_yaml]
 ```
 
+1) Navigate to the repository root and load pyradmon:
+   ```csh
+   cd $NOBACKUP/pyradmon-project/pyradmon
+   source load_radmon_config.csh
+   ```
+   
+   **Note:** The load script automatically generates personalized timeseries input yamls:
+   - `user_geosit_timeseries_input.yaml`
+   - `user_m21c_timeseries_input.yaml`
 
-1) Change directory: `cd $NOBACKUP/radmon/pyradmon/offline/timeseries/src`
-2) Load with the appropriate `load_pyradmon_config` `source $NOBACKUP/radmon/pyradmon/load_pyradmon_config.csh`
-3) Create the `user_input_yaml` by copying the existing example yaml. You may name the yaml file whatever you like: `cp test_config.geosfp.yaml user_input_yaml.yaml`
-4) Open and edit yaml to manually make the changes described below under _Timeseries yaml instructions_. 
-5) Run pyradmon timeseries: `python3 pyradmon_driver_timeseries.py user_input_yaml.yaml`
+2) Change to the timeseries source directory:
+   ```sh
+   cd $PYRADMON_TIMESERIES
+   ```
 
-User only needs to edit/make the configuration yaml file that is used in the command above. No other edits should be needed. To do so follow instructions below.
+3) (Optional) Edit the auto-generated user input yaml if you need to customize experiment settings, dates, output directories, or instruments:
+   ```sh
+   vi user_geosit_timeseries_input.yaml
+   # or
+   vi user_m21c_timeseries_input.yaml
+   ```
 
-The timeseries yaml `[user_input_yaml]` requires a number of changes that must be made manually.
+4) Run pyradmon timeseries:
+   ```sh
+   python3 pyradmon_driver_timeseries.py user_geosit_timeseries_input.yaml
+   # or
+   python3 pyradmon_driver_timeseries.py user_m21c_timeseries_input.yaml
+   ```
 
-## Timeseries yaml instructions:
+**Example user_input_yaml structure:**
 
-It is recommended you attempt `Option 1` below and successfully run pyradmon timeseries with it before attempting `Option 2`.
+All values within {}'s must be replaced by the user or are auto-populated by the load script.
+- `{YYYYMMDD}` ~ 20190530
+- `{path_to_pyradmon}` ~ Users local clone of pyradmon https://github.com/GEOS-ESM/pyradmon/tree/develop
+- `{expid}` ~ e5303_m21c_jan18
+- `{PYRADMON_TIMESERIES}` ~ the full path to the timeseries src directory (auto-set by load script)
+- `{expname}` ~ can be anything, ex: m21c_radmon
+- yaml file name ~ test_config_yaml_path.yaml
 
-### Option 1: Yaml configs for M21C & GEOSIT:
-Templates with proper pyradmon configuration for **m21c e5303_m21c_jan18** and **geosit d5294_geosit_jan18**. Change all instances of `{user_id}` to the value produced by running `echo $user`:
-  - offline/timeseries/src/test_config_yaml_path.tmpl.geosit.yaml
-  - offline/timeseries/src/test_config_yaml_path.tmpl.m21c.yaml
+```yaml
+# Section 1: Date Range
+# ---------------------
+startdate: 20200301 000000
+enddate:  20200301 180000
 
-### Option 2: Construction your own yaml config:
+# Section 2: Input Observation Data (directory paths) ~ *will be specific* to m2, geosit, m21c, and the expid (stream)
+# --------------------------------------------------------------------------------------------------------------------
+# M21C Specific
+# -------------
+expid: e5303_m21c_jan18
+data_dirbase: /home/dao_ops/m21c/archive/e5303_m21c_jan18/obs
+runbase: /home/dao_ops/e5303_m21c_jan18/run/
+mstorage: /home/dao_ops/e5303_m21c_jan18/run/mstorage.arc 
+arcbase: /home/dao_ops/m21c/archive/ 
 
-All values within {}'s must be replaced by the user. The yaml should not have any brackets left once edits are completed.
+# Section 3: Output Directories
+# -----------------------------
+expbase: {PYRADMON_TIMESERIES}/m21c_radmon/
+scratch_dir: {PYRADMON_TIMESERIES}/m21c_radmon/scratch/
+output_dir: {PYRADMON_TIMESERIES}/m21c_radmon/radmon/
 
-IMPORTANT: The example is running pyradmon timeseries for M21C. _*Section 2: Input Observation Data (directory paths) will be specific to m2, geosit, m21c, AND the stream (expid)*_. The user may need to edit the entire path for the Section 2 variables not just the {}'s.
+# Section 4: rcfile is the path to this yaml file (the one you have open and are editing that will be used as the [user_input_yaml])
+# ----------------------------------------------------------------------------------------------------------------------------------
+rcfile: {PYRADMON_TIMESERIES}/test_config_yaml_path.tmpl.m21c.yaml 
 
+# Section 5: (Optional) Specific instruments - one, multiple or all
+# Optional ~ you may leave this commented out if you want to run for all. See the satlist.yaml for instrument list (ex: amsua_n15).
+# ---------------------------------------------------------------------------------------------------------------------------------
+instruments: atms_npp              # run one
+#instruments: amsua_n15,amsua_n16  # run multiple - separate instruments by comma 
+#instruments:                      # run all (leave commented out)
 
-```
-# From test_config_yaml_path.skeleton.yaml:
-# -----------------------------------------
+# Section 6: (Optional) Polar
+# ---------------------------
+#rename_date_dir: current
+#scp_userhost: {user_id}@polar
+#scp_path: /www/html/intranet/personnel/{user_id}/{dir}
 
-    """
-    # Section 0: Variable descriptions
-    # --------------------------------
-    {YYYYMMDD} ~ 20190530
-    {HH} ~ 00
-    {path_to_pyradmon} ~ Users local clone of pyradmon 
-    {expid} ~ e5303_m21c_jan18
-    yaml file name ~ test_config_yaml_path.yaml
-    """
-    # --------------------------------
-
-
-    
-    # Section 1: Date Range
-    # ---------------------
-    startdate: {YYYYMMDD} {HH}0000
-    enddate:  {YYYYMMDD} {HH}0000
-
-    # Section 2: Input Observation Data (directory paths) ~ *will be specific* to m2, geosit, m21c, and the expid (stream)
-    # --------------------------------------------------------------------------------------------------------------------
-    expid: {expid}
-    data_dirbase: /home/dao_ops/m21c/archive/{expid}/obs
-    runbase: /home/dao_ops/{expid}/run/
-    mstorage: /home/dao_ops/{expid}/run/mstorage.arc
-    arcbase: /home/dao_ops/m21c/archive/ 
-
-    # Section 3: Output Directories
-    # -----------------------------
-    expbase: /discover/nobackup/{user_id}/radmon/pyradmon/offline/timeseries/src/m21c_radmon
-    scratch_dir: /discover/nobackup/{user_id}/radmon/pyradmon/offline/timeseries/src/m21c_radmon/scratch
-    output_dir: /discover/nobackup/{user_id}/radmon/pyradmon/offline/timeseries/src/m21c_radmon/radmon
-
-    # Section 4: rcfile is the path to this yaml file (the one you have open and are editing that will be used as the [user_input_yaml])
-    # ----------------------------------------------------------------------------------------------------------------------------------
-    rcfile: /discover/nobackup/{user_id}/radmon/pyradmon/offline/timeseries/src/user_input_yaml.yaml
-
-    # Section 5: (Optional) Specific instruments - one, multiple or all
-    # Optional ~ you may leave this commented out if you want to run for all. See the satlist.yaml for instrument list (ex: amsua_n15).
-    # ---------------------------------------------------------------------------------------------------------------------------------
-    #instruments: amsua_n15            # run one
-    #instruments: amsua_n15,amsua_n16  # run multiple - separate instruments by comma 
-    #instruments:                      # run all
-
-    # Section 6: (Optional) Polar
-    # ---------------------------
-    #rename_date_dir: current
-    #scp_userhost: {user_id}@polar
-    #scp_path: /www/html/intranet/personnel/{user_id}/{dir}
+# Section 7: (No edits) Pyradmon Pointer
+# Section dao_ops version of pyradmon - scripts will point to this rather than the scripts in the locally installed/cloned pyradmon
+# ---------------------------------------------------------------------------------------------------------------------------------
+pyradmon: {PYRADMON_TIMESERIES}
   
-    # Section 7: (No edits) Pyradmon Pointer
-    # Section dao_ops version of pyradmon - scripts will point to this rather than the scripts in the locally installed/cloned pyradmon
-    # ---------------------------------------------------------------------------------------------------------------------------------
-    pyradmon: /home/dao_ops/pyradmon/
-
-      
-    # Section 8: (No edits) Default gsidiag exec and rc file
-    # ------------------------------------------------------
-    bin2txt_exec: /home/dao_ops/GEOSadas-5_29_5_SLES15/GEOSadas/install/bin/gsidiag_bin2txt.x
-    gsidiagsrc: /home/dao_ops/GEOSadas-5_29_5_SLES15/GEOSadas/install/etc/gsidiags.rc
-
-
+# Section 8: (No edits) Default gsidiag exec and rc file
+# ------------------------------------------------------
+bin2txt_exec: /home/dao_ops/GEOSadas-5_29_5_SLES15/GEOSadas/install/bin/gsidiag_bin2txt.x
+gsidiagsrc: /home/dao_ops/GEOSadas-5_29_5_SLES15/GEOSadas/install/etc/gsidiags.rc
 ```
 
+---
 
-#### Description and expected values for {variable}'s:
-- pyradmon will create a new directory using the value of `{expname}` in the timeseries src directory.
-- This new directory will contain 3 subdirectories: `{expid}`, `radmon`, and `scratch`. All the output from pyradmon as well as the temporary files it creates and deletes (plotting yamls,...) get placed in these subdirectories.
-- The `{expid}` directory will contain: Obs data diag txt files used for plotting organized by date - {expname}/{expid}/obs/Y%Y/M%m/D%d/H%H/
-- The `radmon` directory will contain: Plots and tar archive of plots
-- The `scratch` directory will contain: temporary files pyradmon creates, uses, and deletes (plotting yamls,...)
-- *Optional*: User may edit these but is not required to do in order to run pyradmon. See the `satlist.yaml` for instrument list if you wish to use this option.
-- *Polar* : Only for those who wish to run `online version of pyradmon`. Leave commented out or fill in your discover & polar information and uncomment.
+## License
 
+(C) Copyright 2021- United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
 
-</div> 
-</div>
-
-### License:
-
-(C) Copyright 2021- United States Government as represented by the Administrator of the National
-Aeronautics and Space Administration. All Rights Reserved.
-
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-
-
-
-
-</div> 
-</div>
-
-
-<!-- Part 2: extra steps for loading pyradmon
-
-2) Load pyradmon, `mod_pyradmon` you can either create the following function or use the command directly:
-```bash
-mod_pyradmon() {
-  module purge
-  source $NOBACKUP/radmon/pyradmon/load_pyradmon_config.sh
-}
 ```
-This can be put in `~/.bashrc` to ensure it is always active every time the user logins to Discover or in an alternate location, such as `~/.bash_functions` but the user needs to activate these functions via `source ~/.bash_functions`. -->
-
-<!-- 
-To find the appropriate activate script run the following:
-```sh
-ls .venv/radmon_sles15_venv/bin/activate*
-``` -->
-
-<!-- Now activate the virtual environment by running the following (change 'activate.csh' to the appropriate script you just found for your shell):
-```sh
-source .venv/radmon_sles15_venv/bin/activate.csh
-```
-
-Install the dependencies from the requirements.txt file by running:
-```sh
-python3 -m pip install -r requirements.txt
-``` -->
-<!-- 
-
-It is encouraged to use a virtual environment; however, you may choose to not use one. If you do you will have to locate all the references to the *'ACTIVATE_VENV'* variable, which will be explained later, and change them - this will end up being more time consuming. 
-
-
-
-    """
-    # Section 0: Variable descriptions
-    # --------------------------------
-    {YYYYMMDD} ~ 20190530
-    {HH} ~ 00
-    {path_to_pyradmon} ~ Users local clone of pyradmon 
-    {expid} ~ e5303_m21c_jan18
-    {timeseries_src_dir} ~ the full path to the directory src directory (i.e. /discover/nobackup/{user_id}/radmon/pyradmon/offline/timeseries/src)
-    yaml file name ~ test_config_yaml_path.yaml
-    """
--->

--- a/load_radmon_config.csh
+++ b/load_radmon_config.csh
@@ -1,7 +1,93 @@
 #!/bin/csh
 
+# Verifies the load script is being run from repository root directory. 
+if ( $#argv > 0 ) then
+    if ( "$argv[1]" == "-h" || "$argv[1]" == "--help" ) then
+        cat << EOF
+Usage: source $0
+
+Verifies script is run from repository root directory.
+
+Options:
+  -h, --help    Show this message
+EOF
+        exit 0
+    endif
+endif
+
+
+echo "Verifying current directory..."
+echo " "
+
+
+# For sourced scripts, use $_ or just verify we're in the right place
+# Check for required files/directories in current directory
+if ( ! -f "load_radmon_config.csh" || ! -d "offline" ) then
+    echo "Error: Not in repository root"
+    echo "Current directory: $PWD"
+    echo "Please cd to the pyradmon repository root directory"
+    echo "Should contain: load_radmon_config.csh, offline/, etc."
+    exit 1
+endif
+
+
+echo "Current directory Verified."
+echo " "
+
+echo "Loading pyradmon environment..."
+echo " "
+
+
+# Verified - set up environment
+setenv PYRADMON $PWD
+
 # Activate venv and set pyradmon directory environment variable
 source /home/dao_ops/GEOSadas-5_29_5_SLES15/GEOSadas/install/bin/g5_modules
-setenv pyradmon $PWD
 
-echo '$pyradmon set to:' $pyradmon
+setenv PYRADMON_SPATIAL $PYRADMON/offline/spatial/src
+setenv PYRADMON_TIMESERIES $PYRADMON/offline/timeseries/src
+setenv PYRADMON_RUN $PYRADMON/offline/run/
+
+echo '$PYRADMON set to:' $PYRADMON
+
+# update the timeseries yamls automatically
+echo " "
+echo '(Automation) Editing timeseries input yamls with user info ...'
+cp $PYRADMON_TIMESERIES/test_config_yaml_path.tmpl.geosit.yaml $PYRADMON_TIMESERIES/user_geosit_timeseries_input.yaml
+cp $PYRADMON_TIMESERIES/test_config_yaml_path.tmpl.m21c.yaml $PYRADMON_TIMESERIES/user_m21c_timeseries_input.yaml
+sed -i "s/{user_id}/$USER/g" $PYRADMON_TIMESERIES/user_geosit_timeseries_input.yaml
+sed -i "s/{user_id}/$USER/g" $PYRADMON_TIMESERIES/user_m21c_timeseries_input.yaml
+sed -i "s|{PYRADMON_TIMESERIES}|$PYRADMON_TIMESERIES|g" $PYRADMON_TIMESERIES/user_geosit_timeseries_input.yaml
+sed -i "s|{PYRADMON_TIMESERIES}|$PYRADMON_TIMESERIES|g" $PYRADMON_TIMESERIES/user_m21c_timeseries_input.yaml
+sed -i "s|test_config_yaml_path.tmpl.geosit.yaml|user_geosit_timeseries_input.yaml|" $PYRADMON_TIMESERIES/user_geosit_timeseries_input.yaml
+sed -i "s|test_config_yaml_path.tmpl.m21c.yaml|user_m21c_timeseries_input.yaml|" $PYRADMON_TIMESERIES/user_m21c_timeseries_input.yaml
+
+# Check if mod_pyradmon alias exists
+alias mod_pyradmon >& /dev/null
+if ( $? == 0 ) then
+    echo ""
+    #echo "✓ mod_pyradmon alias already exists"
+    echo "-----------------------------------"
+    echo "  pyradmon loaded successfully ✓   "
+    echo "-----------------------------------"
+    echo ""
+
+else
+    cat << 'EOF'
+
+mod_pyradmon alias not found - add this to your .cshrc/.zshrc:
+
+alias mod_pyradmon ' setenv PYRADMON $NOBACKUP/pyradmon-project/pyradmon ; \
+                     cd $PYRADMON ; \
+                     module load miniforge ; \
+                     source $PYRADMON/load_radmon_config.csh'
+
+-----------------------------------
+ pyradmon loaded successfully ✓ 
+-----------------------------------
+
+
+EOF
+endif
+
+# echo "pyradmon loaded successfully."

--- a/load_radmon_config.sh
+++ b/load_radmon_config.sh
@@ -1,7 +1,83 @@
-#!/bin/sh
+#!/bin/bash
+
+# Verifies the load script is being run from repository root directory.
+if [ $# -gt 0 ]; then
+    if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+        cat << EOF
+Usage: source $0
+
+Verifies script is run from repository root directory.
+
+Options:
+  -h, --help    Show this message
+EOF
+        return 0
+    fi
+fi
+
+echo "Verifying current directory..."
+echo " "
+
+# For sourced scripts, verify we're in the right place
+# Check for required files/directories in current directory
+if [ ! -f "load_radmon_config.sh" ] || [ ! -d "offline" ]; then
+    echo "Error: Not in repository root"
+    echo "Current directory: $PWD"
+    echo "Please cd to the pyradmon repository root directory"
+    echo "Should contain: load_radmon_config.sh, offline/, etc."
+    return 1
+fi
+
+echo "Current directory Verified."
+echo " "
+
+echo "Loading pyradmon environment..."
+echo " "
+
+# Verified - set up environment
+export PYRADMON=$PWD
 
 # Activate venv and set pyradmon directory environment variable
 source /home/dao_ops/GEOSadas-5_29_5_SLES15/GEOSadas/install/bin/g5_modules
-export pyradmon="$PWD"
 
-echo '$pyradmon set to:' "$pyradmon"
+export PYRADMON_SPATIAL=$PYRADMON/offline/spatial/src
+export PYRADMON_TIMESERIES=$PYRADMON/offline/timeseries/src
+export PYRADMON_RUN=$PYRADMON/offline/run/
+
+echo "\$PYRADMON set to: $PYRADMON"
+
+# update the timeseries yamls automatically
+echo " "
+echo '(Automation) Editing timeseries input yamls with user info ...'
+cp $PYRADMON_TIMESERIES/test_config_yaml_path.tmpl.geosit.yaml $PYRADMON_TIMESERIES/user_geosit_timeseries_input.yaml
+cp $PYRADMON_TIMESERIES/test_config_yaml_path.tmpl.m21c.yaml $PYRADMON_TIMESERIES/user_m21c_timeseries_input.yaml
+sed -i "s/{user_id}/$USER/g" $PYRADMON_TIMESERIES/user_geosit_timeseries_input.yaml
+sed -i "s/{user_id}/$USER/g" $PYRADMON_TIMESERIES/user_m21c_timeseries_input.yaml
+sed -i "s|{PYRADMON_TIMESERIES}|$PYRADMON_TIMESERIES|g" $PYRADMON_TIMESERIES/user_geosit_timeseries_input.yaml
+sed -i "s|{PYRADMON_TIMESERIES}|$PYRADMON_TIMESERIES|g" $PYRADMON_TIMESERIES/user_m21c_timeseries_input.yaml
+sed -i "s|test_config_yaml_path.tmpl.geosit.yaml|user_geosit_timeseries_input.yaml|" $PYRADMON_TIMESERIES/user_geosit_timeseries_input.yaml
+sed -i "s|test_config_yaml_path.tmpl.m21c.yaml|user_m21c_timeseries_input.yaml|" $PYRADMON_TIMESERIES/user_m21c_timeseries_input.yaml
+
+# Check if mod_pyradmon alias exists
+if alias mod_pyradmon &>/dev/null; then
+    echo ""
+    echo "-----------------------------------"
+    echo "  pyradmon loaded successfully ✓   "
+    echo "-----------------------------------"
+    echo ""
+else
+    cat << 'EOF'
+
+mod_pyradmon alias not found - add this to your .bashrc/.zshrc:
+
+alias mod_pyradmon='export PYRADMON=$NOBACKUP/pyradmon-project/pyradmon ; \
+                    cd $PYRADMON ; \
+                    module load miniforge ; \
+                    source $PYRADMON/load_radmon_config.sh'
+
+-----------------------------------
+ pyradmon loaded successfully ✓ 
+-----------------------------------
+
+EOF
+fi

--- a/load_radmon_config.tcsh
+++ b/load_radmon_config.tcsh
@@ -1,7 +1,0 @@
-#!/bin/tcsh
-
-# Activate venv and set pyradmon directory environment variable
-source /home/dao_ops/GEOSadas-5_29_5_SLES15/GEOSadas/install/bin/g5_modules
-setenv pyradmon "$PWD"
-
-echo '$pyradmon set to:' "$pyradmon"

--- a/load_radmon_config.zsh
+++ b/load_radmon_config.zsh
@@ -1,7 +1,0 @@
-#!/bin/zsh
-
-# Activate venv and set pyradmon directory environment variable
-source /home/dao_ops/GEOSadas-5_29_5_SLES15/GEOSadas/install/bin/g5_modules
-export pyradmon="$PWD"
-
-echo '$pyradmon set to:' "$pyradmon"

--- a/offline/timeseries/src/test_config_yaml_path.skeleton.yaml
+++ b/offline/timeseries/src/test_config_yaml_path.skeleton.yaml
@@ -27,13 +27,13 @@ arcbase: /home/dao_ops/m21c/archive/
 
 # Section 3: Output Directories
 # -----------------------------
-expbase: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/m21c_radmon
-scratch_dir: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/m21c_radmon/scratch
-output_dir: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/m21c_radmon/radmon
+expbase: {PYRADMON_TIMESERIES}/m21c_radmon
+scratch_dir: {PYRADMON_TIMESERIES}/m21c_radmon/scratch
+output_dir: {PYRADMON_TIMESERIES}/m21c_radmon/radmon
 
 # Section 4: rcfile is the path to this yaml file (the one you have open and are editing that will be used as the [user_input_yaml])
 # ----------------------------------------------------------------------------------------------------------------------------------
-rcfile: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/user_input_yaml.yaml
+rcfile: {PYRADMON_TIMESERIES}/test_config_yaml_path.skeleton.yaml
 
 # Section 5: (Optional) Specific instruments - one, multiple or all
 # Optional ~ you may leave this commented out if you want to run for all. See the satlist.yaml for instrument list (ex: amsua_n15).
@@ -51,7 +51,7 @@ rcfile: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/tim
 # Section 7: (No edits) Pyradmon Pointer
 # Section dao_ops version of pyradmon - scripts will point to this rather than the scripts in the locally installed/cloned pyradmon
 # ---------------------------------------------------------------------------------------------------------------------------------
-pyradmon: /home/dao_ops/pyradmon/
+pyradmon: {PYRADMON_TIMESERIES}
 
   
 # Section 8: (No edits) Default gsidiag exec and rc file

--- a/offline/timeseries/src/test_config_yaml_path.tmpl.geosit.yaml
+++ b/offline/timeseries/src/test_config_yaml_path.tmpl.geosit.yaml
@@ -25,13 +25,13 @@ arcbase: /discover/nobackup/projects/gmao/geos-it/dao_ops/archive/
 
 # Section 3: Output Directories
 # -----------------------------
-expbase: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/geosit_radmon/
-scratch_dir: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/geosit_radmon/scratch/
-output_dir: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/geosit_radmon/radmon/
+expbase: {PYRADMON_TIMESERIES}/geosit_radmon/
+scratch_dir: {PYRADMON_TIMESERIES}/geosit_radmon/scratch/
+output_dir: {PYRADMON_TIMESERIES}/geosit_radmon/radmon/
 
 # Section 4: rcfile is the path to this yaml file (the one you have open and are editing that will be used as the [user_input_yaml])
 # ----------------------------------------------------------------------------------------------------------------------------------
-rcfile: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/test_config_yaml_path.tmpl.geosit.yaml
+rcfile: {PYRADMON_TIMESERIES}/test_config_yaml_path.tmpl.geosit.yaml
 
 # Section 5: (Optional) Specific instruments - one, multiple or all
 # Optional ~ you may leave this commented out if you want to run for all. See the satlist.yaml for instrument list (ex: amsua_n15).
@@ -49,7 +49,7 @@ instruments: atms_npp            # run one
 # Section 7: (No edits) Pyradmon Pointer
 # Section dao_ops version of pyradmon - scripts will point to this rather than the scripts in the locally installed/cloned pyradmon
 # ---------------------------------------------------------------------------------------------------------------------------------
-pyradmon: /home/dao_ops/pyradmon/
+pyradmon: {PYRADMON_TIMESERIES}
   
 # Section 8: (No edits) Default gsidiag exec and rc file
 # ------------------------------------------------------

--- a/offline/timeseries/src/test_config_yaml_path.tmpl.m21c.yaml
+++ b/offline/timeseries/src/test_config_yaml_path.tmpl.m21c.yaml
@@ -27,13 +27,13 @@ arcbase: /home/dao_ops/m21c/archive/
 
 # Section 3: Output Directories
 # -----------------------------
-expbase: /discover/nobackup/{user_id}/pyradmon-dao-ops-pointer/offline/timeseries/src/m21c_radmon/
-scratch_dir: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/m21c_radmon/scratch/
-output_dir: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/m21c_radmon/radmon/
+expbase: {PYRADMON_TIMESERIES}/m21c_radmon/
+scratch_dir: {PYRADMON_TIMESERIES}/m21c_radmon/scratch/
+output_dir: {PYRADMON_TIMESERIES}/m21c_radmon/radmon/
 
 # Section 4: rcfile is the path to this yaml file (the one you have open and are editing that will be used as the [user_input_yaml])
 # ----------------------------------------------------------------------------------------------------------------------------------
-rcfile: /discover/nobackup/{user_id}/radmon/pyradmon-dao-ops-pointer/offline/timeseries/src/test_config_yaml_path.tmpl.m21c.yaml 
+rcfile: {PYRADMON_TIMESERIES}/test_config_yaml_path.tmpl.m21c.yaml 
 
 # Section 5: (Optional) Specific instruments - one, multiple or all
 # Optional ~ you may leave this commented out if you want to run for all. See the satlist.yaml for instrument list (ex: amsua_n15).
@@ -51,7 +51,7 @@ instruments: atms_npp              # run one
 # Section 7: (No edits) Pyradmon Pointer
 # Section dao_ops version of pyradmon - scripts will point to this rather than the scripts in the locally installed/cloned pyradmon
 # ---------------------------------------------------------------------------------------------------------------------------------
-pyradmon: /home/dao_ops/pyradmon/
+pyradmon: {PYRADMON_TIMESERIES}
   
 # Section 8: (No edits) Default gsidiag exec and rc file
 # ------------------------------------------------------


### PR DESCRIPTION
Title: Streamline install; auto-generate timeseries YAMLs; unify config paths; update README/CHANGELOG

TL;DR
- One-step environment load with repo-root verification
- Auto-creates user timeseries input YAMLs with correct user and paths
- Templates now use {PYRADMON_TIMESERIES} (no hard-coded /discover paths)
- Removed duplicate tcsh/zsh loaders; consolidated to .sh and .csh
- README and CHANGELOG updated

What changed
- load_radmon_config.sh, load_radmon_config.csh
  - Verify script is sourced from repo root; fail fast with guidance
  - Set PYRADMON, PYRADMON_TIMESERIES, PYRADMON_SPATIAL, PYRADMON_RUN
  - Source GEOS g5_modules
  - Auto-generate:
    - user_geosit_timeseries_input.yaml
    - user_m21c_timeseries_input.yaml
    - Replace {user_id} with $USER and {PYRADMON_TIMESERIES} with actual path
    - Update references from test_config_yaml_path.* to user_* equivalents
  - Check for mod_pyradmon alias; print add-to-shell instructions and success banner
- Removed: load_radmon_config.tcsh, load_radmon_config.zsh (duplicates)
- Templates updated (offline/timeseries/src):
  - test_config_yaml_path.skeleton.yaml
  - test_config_yaml_path.tmpl.geosit.yaml
  - test_config_yaml_path.tmpl.m21c.yaml
  - Switched expbase/scratch_dir/output_dir/rcfile/pyradmon to {PYRADMON_TIMESERIES}
- README: installation/usage streamlined (large diff)
- CHANGELOG: entry added

Why
- Reduce setup friction and manual path edits
- Eliminate path typos and improve reproducibility
- Simplify maintenance by removing redundant loader scripts

Breaking/behavior changes
- tcsh/zsh-specific loader scripts removed. Use:
  - bash/zsh: source ./load_radmon_config.sh
  - csh/tcsh: source ./load_radmon_config.csh
- Default output and rcfile paths now under $PYRADMON/offline/timeseries/src via {PYRADMON_TIMESERIES}
  - If you depended on old /discover/nobackup/... paths, update your scripts or edit the generated user_* YAMLs
- Load scripts must be run from repo root

How to test
1) From repo root:
   - bash/zsh: source ./load_radmon_config.sh
   - csh/tcsh: source ./load_radmon_config.csh
2) Confirm env:
   - echo $PYRADMON, $PYRADMON_TIMESERIES, $PYRADMON_SPATIAL, $PYRADMON_RUN
3) Verify files created with substitutions:
   - offline/timeseries/src/user_geosit_timeseries_input.yaml
   - offline/timeseries/src/user_m21c_timeseries_input.yaml
4) Run a sample timeseries (e.g., atms_npp) and confirm outputs under geosit_radmon/ or m21c_radmon/ within $PYRADMON_TIMESERIES
5) (Optional) Add mod_pyradmon alias as suggested; open a new shell; run mod_pyradmon and confirm success banner

Notes for reviewers
- Focus on correctness of sed substitutions and path tokens in templates
- Confirm return/exit behavior is safe for sourced scripts
- Validate the g5_modules path (/home/dao_ops/GEOSadas-5_29_5_SLES15/...) in your environment

Meta
- 1 commit, 9 files changed (+411 / -254)
- No changes to processing logic; configuration/docs only